### PR TITLE
Inclusão da cotação USD e EUR e correção de bug quando o nome-auxiliar é vazio

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,18 +1,19 @@
-!(function(){
-      const element = document.querySelector('.nome-auxiliar')
-  if (element) {
-    fetch(
-      `https://db.ygoprodeck.com/api/v7/cardinfo.php?name=${encodeURIComponent(
-        element.textContent
-      )}`
-    )
-      .then(res => res.json())
-      .then(({ data }) => {
-        const {
-          card_prices
-        } = data[0]
+(async function(){
+  const englishNameElement = document.querySelector('.nome-auxiliar');
+  const portugueseNameElement = document.querySelector('.nome-principal span');
 
-        const element = `<div class="" align="center">
+  if (englishNameElement && portugueseNameElement) {
+    const quote = await fetch("https://economia.awesomeapi.com.br/last/USD-BRL,EUR-BRL");
+    const { USDBRL, EURBRL } = await quote.json();
+    const { ask: dollar } = USDBRL;
+    const { ask: euro } = EURBRL;
+
+    const cardName = englishNameElement.textContent || portugueseNameElement.textContent;
+    const res = await fetch(`https://db.ygoprodeck.com/api/v7/cardinfo.php?name=${encodeURIComponent(cardName)}`);
+    const { data } = await res.json();
+    const { card_prices } = data[0];
+
+    const element = `<div class="" align="center">
   <div
     class="row bloco-preco-superior"
     title="Preço Médio card Normal (Sem extras)"
@@ -22,7 +23,7 @@
     <div class="col-sep"><div class="circle"></div></div>
     <div class="col-prc col-prc-menor"font-size: 1.255rem">$ ${card_prices[0].tcgplayer_price}</div>
     <div class="col-sep"><div class="circle"></div></div>
-    <div class="col-prc col-prc-maior">R$ ${(card_prices[0].tcgplayer_price * 5).toFixed(2)}</div>
+    <div class="col-prc col-prc-maior">R$ ${(card_prices[0].tcgplayer_price * dollar).toFixed(2)}</div>
   </div>
   <div
     class="row bloco-preco-superior"
@@ -33,16 +34,14 @@
     <div class="col-sep"><div class="circle"></div></div>
     <div class="col-prc col-prc-menor"font-size: 1.255rem">€ ${card_prices[0].cardmarket_price}</div>
     <div class="col-sep"><div class="circle"></div></div>
-    <div class="col-prc col-prc-maior">R$ ${(card_prices[0].cardmarket_price * 5.25).toFixed(2)}</div>
+    <div class="col-prc col-prc-maior">R$ ${(card_prices[0].cardmarket_price * euro).toFixed(2)}</div>
   </div>
 </div>
 
-        `
-        document.querySelector('.desktop-price-lines-0').innerHTML += element;
-        console.log(data)
-      })
+        `;
+    document.querySelector('.desktop-price-lines-0').innerHTML += element;
+    console.log(data);
   } else {
     console.log('Element with class "nome-auxiliar" not found')
   }
-
-})()
+})();


### PR DESCRIPTION
Aproveitei para incluir a consulta do valor médio da cotação do dia (Dolar e Euro) usando a API do `AwesomeAPI`.
E também corrigi um bug onde os valores não eram mostrados nos casos que o `nome-auxiliar` era vazio (como o `Purrely`, por exemplo, já que é o mesmo nome em PT e EN o nome dele fica apenas no `nome-principal`).

@victorgodoka